### PR TITLE
feature: add log error feature

### DIFF
--- a/chatbot-builder/src/androidMain/kotlin/com/hexascribe/chatbotbuilder/logger/PlatformLogger.kt
+++ b/chatbot-builder/src/androidMain/kotlin/com/hexascribe/chatbotbuilder/logger/PlatformLogger.kt
@@ -1,0 +1,18 @@
+package com.hexascribe.chatbotbuilder.logger
+
+import android.util.Log
+
+internal actual object PlatformLogger {
+
+    actual fun logError(exception: Throwable) {
+        logError(TAG_ERROR, exception)
+    }
+
+    actual fun logError(tag: String, exception: Throwable) {
+        logError(tag, exception.message.orEmpty(), exception)
+    }
+
+    actual fun logError(tag: String, message: String, exception: Throwable) {
+        Log.e(tag, message, exception)
+    }
+}

--- a/chatbot-builder/src/commonMain/kotlin/com/hexascribe/chatbotbuilder/base/BaseBuilder.kt
+++ b/chatbot-builder/src/commonMain/kotlin/com/hexascribe/chatbotbuilder/base/BaseBuilder.kt
@@ -134,6 +134,16 @@ public abstract class BaseBuilder<COLOR, IMAGE : Any, VIEW : Any> {
     }
 
     /**
+     * Sets the log error flag.
+     * @param isEnabled Specifies whether logging of errors should be enabled or not.
+     * @return The instance of the BaseBuilder with the updated log error flag.
+     */
+    public fun setLogError(isEnabled: Boolean): BaseBuilder<COLOR, IMAGE, VIEW> {
+        defaults.isLogErrorEnabled = isEnabled
+        return this
+    }
+
+    /**
      * Creates an ImageBitmap object from the provided UIImage.
      * @param image The UIImage to be converted.
      * @return The corresponding ImageBitmap, or null if conversion fails.

--- a/chatbot-builder/src/commonMain/kotlin/com/hexascribe/chatbotbuilder/chat/model/ChatDefaults.kt
+++ b/chatbot-builder/src/commonMain/kotlin/com/hexascribe/chatbotbuilder/chat/model/ChatDefaults.kt
@@ -30,6 +30,7 @@ internal data class ChatDefaults(
     var inputFieldHint: String = "Send a message",
     var botIconBitmap: ImageBitmap? = null,
     var maxTokens: Int = 1024,
+    var isLogErrorEnabled: Boolean = false,
 ) {
 
     val colors by lazy {

--- a/chatbot-builder/src/commonMain/kotlin/com/hexascribe/chatbotbuilder/chat/state/ChatState.kt
+++ b/chatbot-builder/src/commonMain/kotlin/com/hexascribe/chatbotbuilder/chat/state/ChatState.kt
@@ -3,11 +3,12 @@ package com.hexascribe.chatbotbuilder.chat.state
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import co.yml.ychat.YChat
+import co.yml.ychat.entrypoint.features.ChatCompletions
 import com.hexascribe.chatbotbuilder.base.RoleEnum
 import com.hexascribe.chatbotbuilder.chat.model.ChatDefaults
 import com.hexascribe.chatbotbuilder.chat.model.MessageType
-import co.yml.ychat.YChat
-import co.yml.ychat.entrypoint.features.ChatCompletions
+import com.hexascribe.chatbotbuilder.logger.PlatformLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -50,7 +51,7 @@ internal class ChatState(
         runCatching { chatCompletions.execute(messageToSend) }
             .also { onLoading(false) }
             .onSuccess { messages.add(MessageType.Bot(it.first().content)) }
-            .onFailure { onError(true) }
+            .onFailure { handleFailure(it) }
     }
 
     private fun onLoading(isLoading: Boolean) {
@@ -61,6 +62,11 @@ internal class ChatState(
             messages.remove(MessageType.Loading)
         }
         verifyButtonVisible()
+    }
+
+    private fun handleFailure(throwable: Throwable) {
+        if (chatDefaults.isLogErrorEnabled) PlatformLogger.logError(throwable)
+        onError(true)
     }
 
     private fun onError(isError: Boolean) {

--- a/chatbot-builder/src/commonMain/kotlin/com/hexascribe/chatbotbuilder/logger/PlatformLogger.kt
+++ b/chatbot-builder/src/commonMain/kotlin/com/hexascribe/chatbotbuilder/logger/PlatformLogger.kt
@@ -1,0 +1,10 @@
+package com.hexascribe.chatbotbuilder.logger
+
+internal expect object PlatformLogger {
+
+    fun logError(exception: Throwable)
+    fun logError(tag: String, exception: Throwable)
+    fun logError(tag: String, message: String, exception: Throwable)
+}
+
+internal const val TAG_ERROR = "ChatBot-Builder Error"

--- a/chatbot-builder/src/iosMain/kotlin/com/hexascribe/chatbotbuilder/logger/PlatformLogger.kt
+++ b/chatbot-builder/src/iosMain/kotlin/com/hexascribe/chatbotbuilder/logger/PlatformLogger.kt
@@ -1,0 +1,17 @@
+package com.hexascribe.chatbotbuilder.logger
+
+internal actual object PlatformLogger {
+
+    actual fun logError(exception: Throwable) {
+        logError(TAG_ERROR, exception)
+    }
+
+    actual fun logError(tag: String, exception: Throwable) {
+        logError(tag, exception.message.orEmpty(), exception)
+    }
+
+    actual fun logError(tag: String, message: String, exception: Throwable) {
+        println("$tag : $message")
+        println(exception)
+    }
+}

--- a/samples/android/src/androidMain/kotlin/com/hexascribe/chatbotbuilder/MainActivity.kt
+++ b/samples/android/src/androidMain/kotlin/com/hexascribe/chatbotbuilder/MainActivity.kt
@@ -23,6 +23,7 @@ fun ChatScreen() {
         .addMessage(RoleEnum.ASSISTANT, "Hi, how can I help you today?")
         .addPreSeededMessage(RoleEnum.SYSTEM, "You are a helpful seller car assistant")
         .setInputFieldBorderWidth(1)
+        .setLogError(true)
         .build()
     chatBot.ComposeScreen()
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply, remove checkboxes from remaining 
-->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

This pull request introduces a new feature to the method builder class, allowing for better error handling when issues arise. The added feature is a log error flag that can be set to true or false, with the default value being false. This enhancement aims to facilitate the identification and handling of potential errors.

## :bulb: Motivation and Context
Because of this issue https://github.com/hexascribe/chatbot-builder/issues/3

## :green_heart: How did you test it?
Tested on Android Sample

## :camera_flash: Screenshots / GIFs
Log Error Flag enabled, passing a wrong OpenAI API Key

![image](https://github.com/hexascribe/chatbot-builder/assets/40952615/2367061e-2ef8-4932-84a2-afa0437d2b3a)